### PR TITLE
🐛 fix: Correct site URL to deployment link

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,7 +8,7 @@ import react from '@astrojs/react';
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://example.com",
+  site: "https://fasealterna.netlify.app",
   vite: {
     plugins: [tailwindcss()],
   },


### PR DESCRIPTION
# fix: Correct site URL to deployment link

Configura la propiedad `site` en `defineConfig` con el dominio de producción (ejemplo: `"https://fasealterna.netlify.app"`) para que Astro genere URLs absolutas correctas para SEO, mapas del sitio y redes sociales.


