### PR TITLE
✨ feat: enhance concert loading UI with skeleton component

### DIFF
--- a/src/components/SkeletonConcertTable.astro
+++ b/src/components/SkeletonConcertTable.astro
@@ -1,0 +1,15 @@
+---
+type TSkeletonTable = { rows: number }
+
+const { rows } = Astro.props as TSkeletonTable;
+---
+
+
+<div class="flex flex-col">
+    {
+        Array.from({length: rows}, () => 
+        <div class="animate-pulse h-10 w-full odd:bg-[rgba(128,128,128,0.4)] even:bg-[rgba(128,128,128,0.2)] px-4 py-2">
+        </div>)
+    }
+    
+</div>

--- a/src/pages/conciertos.astro
+++ b/src/pages/conciertos.astro
@@ -4,6 +4,7 @@ import Social from "../components/Social.astro";
 import ConcertTable from "../components/ConcertTable.astro";
 import Footer from "../components/Footer.astro";
 import BaseHead from "../components/BaseHead.astro";
+import SkeletonConcertTable from "../components/SkeletonConcertTable.astro";
 
 import faLogo from "../assets/logo-w-box.png";
 import { Image } from "astro:assets";
@@ -52,7 +53,7 @@ const HEAD_CONTENT = {
       </h2>
       <section class="w-full max-w-4xl p-6 text-white">
         <ConcertTable server:defer >
-          <span slot="fallback" class="text-xl opacity-70">Cargando conciertos...</span>
+           <SkeletonConcertTable slot="fallback" rows={5} />
         </ConcertTable>
       </section>
       <div class="pt-20">


### PR DESCRIPTION
# Agregar Skeleton Loader para la Tabla de Conciertos

<img width="1307" height="614" alt="image" src="https://github.com/user-attachments/assets/31535628-a053-49db-85c0-5dfc110799d1" />

Se ha implementado un nuevo componente llamado `SkeletonConcertTable` que permite mostrar una animación de carga mientras se obtienen los datos de la tabla de conciertos.

Este componente acepta una prop `rows` que define la cantidad de filas a renderizar durante el estado de carga.

## ✨ Ventajas de usar Skeleton Loaders

* ⏳ **Mejor experiencia de usuario**: Los Skeleton Loaders hacen que la interfaz se sienta más rápida y reactiva, incluso cuando los datos están siendo cargados desde una API u otra fuente externa.
* 😊 **Reduce la percepción de espera**: Al mostrar una representación visual del contenido que está por llegar, se evita mostrar pantallas en blanco o indicadores genéricos de carga.
* 🌟 **Transición suave**: Permite una transición más natural entre el estado de carga y el contenido real.

Este cambio mejora la interacción del usuario en momentos donde el fetching de datos puede tardar, especialmente en conexiones lentas o con muchas filas por mostrar.



